### PR TITLE
41_Controllerのテストと入力チェックのテスト

### DIFF
--- a/src/main/java/raisetech/student/management/controller/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/student/management/controller/GlobalExceptionHandler.java
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
     Map<String, String> error = new HashMap<>();
-    error.put("error", ex.getMessage());
+    error.put("error","入力値に誤りがあります。");
 
     return ResponseEntity.badRequest().body(error);
   }
@@ -47,7 +47,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<Map<String, String>> handleNotFound(
       EmptyResultDataAccessException exception) {
     Map<String, String> error = new HashMap<>();
-    error.put("error", exception.getMessage());
+    error.put("error","指定されたデータは存在しません。");
 
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
   }

--- a/src/main/java/raisetech/student/management/controller/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/student/management/controller/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package raisetech.student.management.controller;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -10,9 +11,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
   // 例1: バリデーションエラー用（@Validで失敗した時）
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<Map<String, String>> handleValidationErrors(MethodArgumentNotValidException ex) {
+  public ResponseEntity<Map<String, String>> handleValidationErrors(
+      MethodArgumentNotValidException ex) {
     Map<String, String> errors = new HashMap<>();
 
     ex.getBindingResult().getFieldErrors().forEach(error ->
@@ -38,5 +41,14 @@ public class GlobalExceptionHandler {
     error.put("error", "システムエラーが発生しました");
 
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+  }
+
+  @ExceptionHandler(EmptyResultDataAccessException.class)
+  public ResponseEntity<Map<String, String>> handleNotFound(
+      EmptyResultDataAccessException exception) {
+    Map<String, String> error = new HashMap<>();
+    error.put("error", exception.getMessage());
+
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
   }
 }

--- a/src/main/java/raisetech/student/management/controller/request/UpdateStudentFieldRequest.java
+++ b/src/main/java/raisetech/student/management/controller/request/UpdateStudentFieldRequest.java
@@ -1,9 +1,6 @@
 package raisetech.student.management.controller.request;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/raisetech/student/management/controller/request/UpdateStudentFieldRequest.java
+++ b/src/main/java/raisetech/student/management/controller/request/UpdateStudentFieldRequest.java
@@ -1,7 +1,12 @@
 package raisetech.student.management.controller.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -9,14 +14,25 @@ import raisetech.student.management.controller.validation.ValidFieldValue;
 
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @ValidFieldValue
 public class UpdateStudentFieldRequest {
 
-  @NotBlank
+  @NotBlank(message = "値を入力してください")
   private String value;
-  @NotBlank
+
+  @NotBlank(message = "フィールド名を入力してください")
+  @Pattern(regexp = "^(name|furigana|nickname|mailAddress|address|age|gender|remark)?$", message = "正しいフィールド名を入力してください")
   private String field;
-  @NotNull
+
+  @NotNull(message = "StudentIdは必須です")
   private Integer studentId;
 
+
+  public UpdateStudentFieldRequest(String field, String value) {
+    this.field = field;
+    this.value = value;
+    this.studentId = 1; // テスト用に適当な値
+  }
 }

--- a/src/main/java/raisetech/student/management/controller/request/UpdateStudentFieldRequest.java
+++ b/src/main/java/raisetech/student/management/controller/request/UpdateStudentFieldRequest.java
@@ -1,12 +1,15 @@
 package raisetech.student.management.controller.request;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import raisetech.student.management.controller.validation.ValidFieldValue;
+
 @Getter
 @Setter
-
+@ValidFieldValue
 public class UpdateStudentFieldRequest {
 
   @NotBlank

--- a/src/main/java/raisetech/student/management/controller/validation/FieldValueValidator.java
+++ b/src/main/java/raisetech/student/management/controller/validation/FieldValueValidator.java
@@ -17,11 +17,15 @@ public class FieldValueValidator implements ConstraintValidator<ValidFieldValue,
     String field = request.getField();
     String value = request.getValue();
 
+    if (field == null || value == null) {
+      return false;
+    }
+
     return switch (field) {
       case "name", "furigana", "nickname", "address" -> !value.isBlank();
       case "remark"->value.length()<=200;
-      case "gender"->value.matches("^(男性|女性|その他)$");
-      case "mailAddress"->value.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+      case "gender"-> value.matches("^(男性|女性|その他)$");
+      case "mailAddress" -> value.matches("^[\\w.%+-]+@[\\w.-]+\\.[a-zA-Z]{2,}$");
       case "age" -> value.matches("^[1-9][0-9]*$");
       default -> false;
     };

--- a/src/main/java/raisetech/student/management/controller/validation/FieldValueValidator.java
+++ b/src/main/java/raisetech/student/management/controller/validation/FieldValueValidator.java
@@ -1,0 +1,29 @@
+package raisetech.student.management.controller.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import raisetech.student.management.controller.request.UpdateStudentFieldRequest;
+
+/**
+ * ValidFieldValue アノテーションに対応する実際の検証ロジック。
+ */
+public class FieldValueValidator implements ConstraintValidator<ValidFieldValue, UpdateStudentFieldRequest> {
+
+  @Override
+  public boolean isValid(UpdateStudentFieldRequest request, ConstraintValidatorContext context) {
+    if (request == null) {
+      return true;
+    }
+    String field = request.getField();
+    String value = request.getValue();
+
+    return switch (field) {
+      case "name", "furigana", "nickname", "address" -> !value.isBlank();
+      case "remark"->value.length()<=200;
+      case "gender"->value.matches("^(男性|女性|その他)$");
+      case "mailAddress"->value.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+      case "age" -> value.matches("^[1-9][0-9]*$");
+      default -> false;
+    };
+  }
+}

--- a/src/main/java/raisetech/student/management/controller/validation/ValidFieldValue.java
+++ b/src/main/java/raisetech/student/management/controller/validation/ValidFieldValue.java
@@ -1,0 +1,24 @@
+package raisetech.student.management.controller.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * UpdateStudentFieldRequest に対して、
+ * field と value の組み合わせが正しいかどうかを検証するアノテーション。
+ */
+@Documented
+@Constraint(validatedBy = FieldValueValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidFieldValue {
+  String message() default "不正なフィールド名または値です";
+  Class<?>[] groups() default {};
+  Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -37,7 +37,6 @@ public class Student {
   @Positive
   private int age;
 
-  @Size(max = 10)
   @NotNull
   @Pattern(regexp = "^(男性|女性|その他)?$", message = "性別は「男性」「女性」「その他」のいずれかを指定してください")
   private String gender;

--- a/src/test/java/raisetech/student/management/controller/StudentApiControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentApiControllerTest.java
@@ -17,14 +17,17 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import raisetech.student.management.controller.converter.StudentConverter;
 import raisetech.student.management.controller.request.LogicalDeleteStudentRequest;
 import raisetech.student.management.controller.request.UpdateStudentFieldRequest;
@@ -33,17 +36,26 @@ import raisetech.student.management.data.Student;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.service.StudentService;
 
-@WebMvcTest(StudentApiController.class)
+@ExtendWith(MockitoExtension.class)
 class StudentApiControllerTest {
 
-  @Autowired
   private MockMvc mockMvc;
 
-  @MockBean
+  @Mock
   private StudentService service;
 
-  @MockBean
+  @Mock
   StudentConverter converter;
+
+  @InjectMocks
+  private StudentApiController controller;
+
+  @BeforeEach
+  void setup() {
+    mockMvc = MockMvcBuilders.standaloneSetup(controller)
+        .setControllerAdvice(new GlobalExceptionHandler())
+        .build();
+  }
 
   private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 

--- a/src/test/java/raisetech/student/management/controller/StudentApiControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentApiControllerTest.java
@@ -1,23 +1,36 @@
 package raisetech.student.management.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import raisetech.student.management.controller.converter.StudentConverter;
+import raisetech.student.management.controller.request.LogicalDeleteStudentRequest;
+import raisetech.student.management.controller.request.UpdateStudentFieldRequest;
+import raisetech.student.management.controller.request.UpdateStudentsCoursesRequest;
 import raisetech.student.management.data.Student;
+import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.service.StudentService;
 
 @WebMvcTest(StudentApiController.class)
@@ -26,15 +39,17 @@ class StudentApiControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
- @MockBean
+  @MockBean
   private StudentService service;
 
- @MockBean StudentConverter converter;
+  @MockBean
+  StudentConverter converter;
 
- private Validator validator= Validation.buildDefaultValidatorFactory().getValidator();
+  private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
   /**
    * 受講生一覧検索のテスト
+   *
    * @throws Exception
    */
   @Test
@@ -42,26 +57,341 @@ class StudentApiControllerTest {
     mockMvc.perform(get("/api/students"))
         .andExpect(status().isOk());
 
-    verify(service,times(1)).getStudentDetail();
+    verify(service, times(1)).getStudentDetail();
   }
 
   /**
+   * studentエンティティの必須項目を正常値で設定したもの
    *
+   * @return student
    */
-  @Test
-  void 受講生詳細の受講生で適切な値を入力した際に異常が発生しないこと(){
+  private Student createValidStudent() {
     Student student = new Student();
     student.setName("田中健一");
     student.setFurigana("タナカケンイチ");
     student.setMailAddress("kenichi.tanaka@aaaa.com");
     student.setAge(20);
     student.setGender("男性");
+    return student;
+  }
+
+  /**
+   * Studentエンティティに対して、全ての必須項目を正しく入力した場合にバリデーションエラーが発生しないことを確認するテスト。
+   */
+  @Test
+  void 受講生詳細の受講生で適切な値を入力した際に異常が発生しないこと() {
+    Student student = createValidStudent();
 
     Set<ConstraintViolation<Student>> violations = validator.validate(student);
 
     assertThat(violations.size()).isEqualTo(0);
   }
 
+  /**
+   * Studentエンティティに対して、nameフィールドのみ不正な値が入力されてた場合に正しくエラーが発生するか確認するテスト
+   */
+  @Test
+  void 受講生詳細の受講生でnameフィールドのエラーを検知すること() {
+    Student student = createValidStudent();
+    student.setName("");
+
+    Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+    assertThat(violations.size()).isEqualTo(1);
+  }
+
+  /**
+   * Studentエンティティに対して、mailAddressフィールドのみ不正な値が入力されてた場合に正しくエラーが発生するか確認するテスト
+   */
+  @Test
+  void 受講生詳細の受講生でmailAddressフィールドのエラーを検知すること() {
+    Student student = createValidStudent();
+    student.setMailAddress("aaa");
+
+    Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+    assertThat(violations.size()).isEqualTo(1);
+  }
+
+  /**
+   * 指定した studentId の受講生情報が取得できることを確認するテスト。
+   *
+   * @throws Exception
+   */
+  @Test
+  void 指定したstudentIdの受講生を検索できること() throws Exception {
+    int studentId = 1;
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(createValidStudent());
+    studentDetail.getStudent().setStudentId(studentId);
+
+    when(service.getStudentDetail(studentId)).thenReturn(studentDetail);
+
+    mockMvc.perform(get("/api/students/{studentId}", studentId))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).getStudentDetail(studentId);
+  }
+
+  @Test
+  void 指定したstudentIdが存在しない場合に404が返ること() throws Exception {
+    int studentId = 999;
+
+    // service側で存在しないIDの場合に例外を投げる設定
+    when(service.getStudentDetail(studentId))
+        .thenThrow(new EmptyResultDataAccessException("Student Not Found", 1));
+
+    mockMvc.perform(get("/api/students/{studentId}", studentId))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error").value("Student Not Found"));
+
+    verify(service, times(1)).getStudentDetail(studentId);
+  }
+
+  /**
+   * 新規受講生登録 API (/api/students) が呼び出せることを確認するテスト。
+   *
+   * @throws Exception MockMvc 実行時の例外
+   */
+  @Test
+  void 新規受講生登録が呼び出せること() throws Exception {
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(createValidStudent());
+
+    when(service.registerStudent(any(StudentDetail.class))).thenReturn(studentDetail);
+
+    mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/students")
+                .contentType("application/json")
+                .content(new ObjectMapper().writeValueAsString(studentDetail)))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).registerStudent(any(StudentDetail.class));
+  }
+
+
+  /**
+   * 新規受講生登録において異常値が入力されたときのテスト nameの場合
+   *
+   * @throws Exception
+   */
+  @Test
+  void 新規受講生登録でnameに不正値を入力した際にエラーが出ること() throws Exception {
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(createValidStudent());
+    studentDetail.getStudent().setName(" ");
+
+    mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/students")
+                .contentType("application/json")
+                .content(new ObjectMapper().writeValueAsString(studentDetail)))
+        .andExpect(status().isBadRequest());
+
+    verify(service, times(0)).registerStudent(any(StudentDetail.class));
+  }
+
+  /**
+   * 新規受講生登録において異常値が入力されたときのテスト mailAddressの場合
+   *
+   * @throws Exception
+   */
+  @Test
+  void 新規受講生登録でmailAddressに不正値を入力した際にエラーが出ること() throws Exception {
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(createValidStudent());
+    studentDetail.getStudent().setMailAddress("aaaa");
+
+    mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/students")
+                .contentType("application/json")
+                .content(new ObjectMapper().writeValueAsString(studentDetail)))
+        .andExpect(status().isBadRequest());
+
+    verify(service, times(0)).registerStudent(any(StudentDetail.class));
+  }
+
+  /**
+   * 受講コース登録 API (/api/students/courses) が呼び出せることを確認するテスト。
+   *
+   * @throws Exception MockMvc 実行時の例外
+   */
+  @Test
+  void 受講コース登録が呼び出せること() throws Exception {
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(createValidStudent());
+
+    when(service.registerCourse(any(StudentDetail.class))).thenReturn(studentDetail);
+
+    mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/students/courses")
+                .contentType("application/json")
+                .content(new ObjectMapper().writeValueAsString(studentDetail)))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).registerCourse(any(StudentDetail.class));
+  }
+
+  /**
+   * 受講生情報更新 API (/api/students PATCH) が呼び出せることを確認するテスト。
+   *
+   * @throws Exception MockMvc 実行時の例外
+   */
+  @Test
+  void 受講生情報更新が呼び出せること() throws Exception {
+    UpdateStudentFieldRequest request = new UpdateStudentFieldRequest();
+    request.setStudentId(1);
+    request.setField("name");
+    request.setValue("田中太郎");
+
+    StudentDetail updatedDetail = new StudentDetail();
+    updatedDetail.setStudent(createValidStudent());
+
+    when(service.updateStudentField(any(UpdateStudentFieldRequest.class)))
+        .thenReturn(updatedDetail);
+
+    mockMvc.perform(
+            patch("/api/students")
+                .contentType("application/json")
+                .content(new ObjectMapper().writeValueAsString(request))
+        )
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).updateStudentField(any(UpdateStudentFieldRequest.class));
+  }
+
+  /**
+   * 受講生情報更新の際に不正値に対してエラーが出ること フィールド名が不正の場合
+   *
+   * @throws Exception
+   */
+  @Test
+  void 受講生情報更新で不正なフィールド名を入力した際にエラーが出ること() throws Exception {
+    UpdateStudentFieldRequest request = new UpdateStudentFieldRequest();
+    request.setStudentId(1);
+    request.setField("password");
+    request.setValue("aaa");
+
+    mockMvc.perform(
+            patch("/api/students")
+                .contentType("application/json")
+                .content(new ObjectMapper().writeValueAsString(request))
+        )
+        .andExpect(status().isBadRequest());
+
+    verify(service, times(0)).updateStudentField(any(UpdateStudentFieldRequest.class));
+  }
+
+  /**
+   * 受講生情報更新の際に不正値に対してエラーが出ること valueのみが不正な場合 カスタムアノテーションで管理
+   *
+   * @throws Exception
+   */
+  @Test
+  void 受講生情報更新で不正なバリュー名を入力した際にエラーが出ること() throws Exception {
+    UpdateStudentFieldRequest request = new UpdateStudentFieldRequest();
+    request.setStudentId(1);
+    request.setField("gender");
+    request.setValue("男");
+
+    mockMvc.perform(
+            patch("/api/students")
+                .contentType("application/json")
+                .content(new ObjectMapper().writeValueAsString(request))
+        )
+        .andExpect(status().isBadRequest());
+
+    verify(service, times(0)).updateStudentField(any(UpdateStudentFieldRequest.class));
+  }
+
+  /**
+   * 受講コース更新 API (/api/students/courses PATCH) が呼び出せることを確認するテスト。
+   *
+   * @throws Exception MockMvc 実行時の例外
+   */
+  @Test
+  void 受講コース更新が呼び出せること() throws Exception {
+    UpdateStudentsCoursesRequest request = new UpdateStudentsCoursesRequest();
+    request.setStudentId(1);
+    request.setCourseIds(List.of(101, 102));
+
+    StudentDetail updatedDetail = new StudentDetail();
+    updatedDetail.setStudent(createValidStudent());
+
+    when(service.updateCourse(any(UpdateStudentsCoursesRequest.class)))
+        .thenReturn(updatedDetail);
+
+    mockMvc.perform(
+            patch("/api/students/courses")
+                .contentType("application/json")
+                .content(new ObjectMapper().writeValueAsString(request))
+        )
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).updateCourse(any(UpdateStudentsCoursesRequest.class));
+  }
+
+  /**
+   *受講コース更新時、存在しないstudentIdに対して404が返ることの確認
+   * @throws Exception
+   */
+  @Test
+  void 受講コース更新時で存在しないstudentIdの指定に対しエラーが出ることを確認するテスト()
+      throws Exception {
+    UpdateStudentsCoursesRequest request = new UpdateStudentsCoursesRequest();
+    request.setStudentId(999);
+    request.setCourseIds(List.of(1, 2));
+
+    when(service.updateCourse(any(UpdateStudentsCoursesRequest.class))).thenThrow(
+        new EmptyResultDataAccessException("Student Not Found", 1));
+
+    mockMvc.perform(patch("/api/students/courses")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(new ObjectMapper().writeValueAsString(request)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error").value("Student Not Found"));
+    verify(service, times(1)).updateCourse(any(UpdateStudentsCoursesRequest.class));
+  }
+
+  /**
+   * 受講生の論理削除・復元のAPIが呼び出せることを確認するテスト
+   */
+  @Test
+  void 受講生の論理削除が呼び出せること() throws Exception {
+    LogicalDeleteStudentRequest request = new LogicalDeleteStudentRequest();
+    request.setToDeleteIds(List.of(1, 2));
+    request.setToRestoreIds(List.of(3));
+
+    when(service.logicalDeleteStudent(request.getToDeleteIds(), request.getToRestoreIds()))
+        .thenReturn(List.of());
+
+    mockMvc.perform(
+            patch("/api/students/logical-delete")
+                .contentType("application/json")
+                .content(new ObjectMapper().writeValueAsString(request))
+        )
+        .andExpect(status().isOk());
+
+    verify(service, times(1))
+        .logicalDeleteStudent(request.getToDeleteIds(), request.getToRestoreIds());
+  }
+
+  @Test
+  void 受講の論理削除で存在しないstudentIdの指定に対しエラーが出ることを確認するテスト()
+      throws Exception {
+    LogicalDeleteStudentRequest request = new LogicalDeleteStudentRequest();
+    request.setToDeleteIds(List.of(1,2));
+    request.setToRestoreIds(List.of(3,4));
+
+    when(service.logicalDeleteStudent(anyList(),anyList())).thenThrow(
+        new EmptyResultDataAccessException("Student Not Found", 1));
+
+    mockMvc.perform(patch("/api/students/logical-delete")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(new ObjectMapper().writeValueAsString(request)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error").value("Student Not Found"));
+    verify(service, times(1)).logicalDeleteStudent(request.getToDeleteIds(),request.getToRestoreIds());
+  }
 
 
 }

--- a/src/test/java/raisetech/student/management/controller/StudentApiControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentApiControllerTest.java
@@ -155,7 +155,7 @@ class StudentApiControllerTest {
 
     mockMvc.perform(get("/api/students/{studentId}", studentId))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.error").value("Student Not Found"));
+        .andExpect(jsonPath("$.error").value("指定されたデータは存在しません。"));
 
     verify(service, times(1)).getStudentDetail(studentId);
   }
@@ -360,7 +360,7 @@ class StudentApiControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(new ObjectMapper().writeValueAsString(request)))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.error").value("Student Not Found"));
+        .andExpect(jsonPath("$.error").value("指定されたデータは存在しません。"));
     verify(service, times(1)).updateCourse(any(UpdateStudentsCoursesRequest.class));
   }
 
@@ -401,7 +401,7 @@ class StudentApiControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(new ObjectMapper().writeValueAsString(request)))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.error").value("Student Not Found"));
+        .andExpect(jsonPath("$.error").value("指定されたデータは存在しません。"));
     verify(service, times(1)).logicalDeleteStudent(request.getToDeleteIds(),request.getToRestoreIds());
   }
 

--- a/src/test/java/raisetech/student/management/controller/StudentApiControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentApiControllerTest.java
@@ -1,0 +1,67 @@
+package raisetech.student.management.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import raisetech.student.management.controller.converter.StudentConverter;
+import raisetech.student.management.data.Student;
+import raisetech.student.management.service.StudentService;
+
+@WebMvcTest(StudentApiController.class)
+class StudentApiControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+ @MockBean
+  private StudentService service;
+
+ @MockBean StudentConverter converter;
+
+ private Validator validator= Validation.buildDefaultValidatorFactory().getValidator();
+
+  /**
+   * 受講生一覧検索のテスト
+   * @throws Exception
+   */
+  @Test
+  void 受講生詳細の一覧検索ができて空のリストが返ってくること() throws Exception {
+    mockMvc.perform(get("/api/students"))
+        .andExpect(status().isOk());
+
+    verify(service,times(1)).getStudentDetail();
+  }
+
+  /**
+   *
+   */
+  @Test
+  void 受講生詳細の受講生で適切な値を入力した際に異常が発生しないこと(){
+    Student student = new Student();
+    student.setName("田中健一");
+    student.setFurigana("タナカケンイチ");
+    student.setMailAddress("kenichi.tanaka@aaaa.com");
+    student.setAge(20);
+    student.setGender("男性");
+
+    Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+    assertThat(violations.size()).isEqualTo(0);
+  }
+
+
+
+}

--- a/src/test/java/raisetech/student/management/controller/validation/FieldValueValidatorTest.java
+++ b/src/test/java/raisetech/student/management/controller/validation/FieldValueValidatorTest.java
@@ -1,0 +1,83 @@
+package raisetech.student.management.controller.validation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import raisetech.student.management.controller.request.UpdateStudentFieldRequest;
+
+class FieldValueValidatorTest {
+
+  FieldValueValidator validator = new FieldValueValidator();
+  ConstraintValidatorContext context = Mockito.mock(ConstraintValidatorContext.class);
+
+  /**
+   * リクエストがnullの際にtrueを返すことを確認するテスト
+   */
+  @Test
+  void nullRequest() {
+    assertTrue(validator.isValid(null, context), "requestがnullの場合はtrue");
+  }
+
+  /**
+   * name, furigana, nickname, addressが!value.isBlank()を満たすことを確認するテスト
+   */
+  @Test
+  void blankField() {
+    assertTrue(validator.isValid(new UpdateStudentFieldRequest("name", "田中健"), context));
+    assertFalse(validator.isValid(new UpdateStudentFieldRequest("name", ""), context));
+    assertFalse(validator.isValid(new UpdateStudentFieldRequest("name", null), context));
+  }
+
+  /**
+   * remarkにおいてvalue.length()<=200を満たすことを確認するテスト
+   */
+  @Test
+  void remarkLength() {
+    assertTrue(validator.isValid(new UpdateStudentFieldRequest("remark", "200文字以内"), context));
+    assertFalse(validator.isValid(new UpdateStudentFieldRequest("remark", null), context));
+    assertFalse(validator.isValid(new UpdateStudentFieldRequest("remark", "a".repeat(201)), context));
+  }
+
+  /**
+   * genderにおいてvalue.matches("^(男性|女性|その他)$")を満たすことを確認するテスト
+   */
+  @Test
+  void gender() {
+    assertTrue(validator.isValid(new UpdateStudentFieldRequest("gender", "男性"), context));
+    assertTrue(validator.isValid(new UpdateStudentFieldRequest("gender", "女性"), context));
+    assertTrue(validator.isValid(new UpdateStudentFieldRequest("gender", "その他"), context));
+    assertFalse(validator.isValid(new UpdateStudentFieldRequest("gender", null), context));
+    assertFalse(validator.isValid(new UpdateStudentFieldRequest("gender", "指定外文字"), context));
+  }
+
+  /**
+   * mailAddressにおいてその形式が守られているかのテスト
+   */
+  @Test
+  void mailAddress() {
+    assertTrue(validator.isValid(new UpdateStudentFieldRequest("mailAddress", "abc@aaa.com"), context));
+    assertFalse(validator.isValid(new UpdateStudentFieldRequest("mailAddress", "aaa"), context));
+    assertFalse(validator.isValid(new UpdateStudentFieldRequest("mailAddress", null), context));
+  }
+
+  /**
+   * ageにおいて値が正の整数であることを確認するテスト
+   */
+  @Test
+  void age() {
+    assertTrue(validator.isValid(new UpdateStudentFieldRequest("age", "1"), context));
+    assertFalse(validator.isValid(new UpdateStudentFieldRequest("age", "-1"), context));
+    assertFalse(validator.isValid(new UpdateStudentFieldRequest("age", "a"), context));
+    assertFalse(validator.isValid(new UpdateStudentFieldRequest("age", null), context));
+  }
+
+  @Test
+  void notApplicableField() {
+    assertFalse(validator.isValid(new UpdateStudentFieldRequest("notApplicableField", "value"), context));
+  }
+
+
+}
+


### PR DESCRIPTION
## 実装内容
- コントローラーのテスト作成
- 異常系も含めて HTTP ステータスとレスポンス内容を検証
- その中でエンティティ自体の制約についてもテスト
- テスト用アノテーションを `MockBean` から `ExtendWith(MockitoExtension.class) + InjectMocks` に切り替え

## 動作確認
- すべてのテストが成功することを確認

## 学んだこと・工夫したところ
- エンティティの制約についてのテストと登録時の入力チェックは別物
- 異常系テストについて、どの段階でエラーを出すのかを意識するのが大事